### PR TITLE
OWASP minimum, `password#as_str`, cache hasher

### DIFF
--- a/lib/devise/encryptable/encryptors/pbkdf2.rb
+++ b/lib/devise/encryptable/encryptors/pbkdf2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Devise
   module Encryptable
     module Encryptors

--- a/lib/devise/encryptable/encryptors/pbkdf2.rb
+++ b/lib/devise/encryptable/encryptors/pbkdf2.rb
@@ -19,7 +19,7 @@ module Devise
         def self.enforce_stretches(stretches)
           return stretches if stretches.to_i >= MIN_STRETCHES
           return MIN_STRETCHES if ALWAYS_OVERRIDE
-          raise ArgumentError, "stretches (#{stretches.inspec}) must be >= #{MIN_STRETCHES}, or set env var #{ENV_OVERRIDE}"
+          raise ArgumentError, "stretches (#{stretches.inspect}) must be >= #{MIN_STRETCHES}, or set env var #{ENV_OVERRIDE}"
         end
 
         def self.compare(encrypted_password, password, stretches, salt, pepper)

--- a/lib/devise/encryptable/encryptors/pbkdf2.rb
+++ b/lib/devise/encryptable/encryptors/pbkdf2.rb
@@ -1,23 +1,40 @@
-begin
-  module Devise
-    module Encryptable
-      module Encryptors
-        class Pbkdf2 < Base
-          def self.compare(encrypted_password, password, stretches, salt, pepper)
-            value_to_test = self.digest(password, stretches, salt, pepper)
-            Devise.secure_compare(encrypted_password, value_to_test)
-          end
+module Devise
+  module Encryptable
+    module Encryptors
+      class Pbkdf2 < Base
+        # Likely source of CVE(s)
+        # Prevent `stretches` from being set to insecure values
+        # OWASP recommendation as of 2023-01-25
+        # https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+        PROD = !(Rails.env.test? || Rails.env.development?)
+        MIN_STRETCHES = PROD ? 600_000 : 1_000
+        ENV_OVERRIDE = 'DEVISE_PBKDF2_CLAMP_STRETCHES_TO_OWASP_MINIMUM'
+        ALWAYS_OVERRIDE = ENV.has_key?(ENV_OVERRIDE) # cache it for performance
+        HASH = 'SHA512'
+        HASH_LENGTH = OpenSSL::Digest.new(HASH).digest_length
 
-          def self.digest(password, stretches, salt, pepper)
-            hash = OpenSSL::Digest.new('SHA512').new
-            OpenSSL::KDF.pbkdf2_hmac(
-              password.to_s,
-              salt: "#{[salt].pack('H*')}#{pepper}",
-              iterations: stretches,
-              hash: hash,
-              length: hash.digest_length,
-            ).unpack1('H*')
-          end
+        # Raises by default so developers are aware of app security configuration
+        def self.enforce_stretches(stretches)
+          return stretches if stretches.to_i >= MIN_STRETCHES
+          return MIN_STRETCHES if ALWAYS_OVERRIDE
+          raise ArgumentError, "stretches (#{stretches.inspec}) must be >= #{MIN_STRETCHES}, or set env var #{ENV_OVERRIDE}"
+        end
+
+        def self.compare(encrypted_password, password, stretches, salt, pepper)
+          stretches = self.enforce_stretches(stretches)
+          value_to_test = self.digest(password, stretches, salt, pepper)
+          Devise.secure_compare(encrypted_password, value_to_test)
+        end
+
+        def self.digest(password, stretches, salt, pepper)
+          stretches = self.enforce_stretches(stretches)
+          OpenSSL::KDF.pbkdf2_hmac(
+            password,
+            salt: "#{[salt].pack('H*')}#{pepper}",
+            iterations: stretches,
+            hash: HASH,
+            length: HASH_LENGTH,
+          ).unpack1('H*')
         end
       end
     end


### PR DESCRIPTION
0. Check `stretches` for sane value, or set env var `DEVISE_PBKDF2_CLAMP_STRETCHES_TO_OWASP_MINIMUM=1` to blindly use the recommended value as of writing. 
1. `password` should implement `#to_str` as accepted by `StringValue();` rather than `#to_s` all objects.
2. `hash` is used in `ossl_evp_get_digestbyname()` as a `String`, so creating a `Digest` is unnecessary.
3. Unsure about unnecessary `begin..end`, possibly loader workaround (zeitwerk, bootsnap, spring) or leftover from a previous `rescue LoadError`.